### PR TITLE
Fixed the simple import example.

### DIFF
--- a/source/includes/_feature-importing.md
+++ b/source/includes/_feature-importing.md
@@ -36,11 +36,15 @@ POST a Dataset Entity to the datasets catalog. See the documentation for [POST /
 #### 2. Upload the file
 
 ```http
+
 POST /sources/ HTTP/1.1
-Content-Type: text/csv
 Content-Length: 8874357
+Content-Type: multipart/form-data; boundary=df5b17ff463a4cb3aa61cf02224c7303
+
+--df5b17ff463a4cb3aa61cf02224c7303
 Content-Disposition: form-data; name="uploaded_file"; filename="my.csv"
-...
+Content-Type: text/csv
+
 "case_id","q1","q2"
 234375,3,"sometimes"
 234376,2,"always"
@@ -60,6 +64,7 @@ POST /datasets/{dataset_id}/batches/ HTTP/1.1
 Content-Type: application/json
 ...
 {
+    "element": "shoji:entity",
     "body": {
         "source": "/sources/{source_id}/"
     }


### PR DESCRIPTION
In first import example, imports happen in 3 steps:

- create empty dataset
- upload a source
- add a batch to the dataset from the source

For upload a source, the example showed posting a CSV body. This
doesn't work. You can post a json body, but CSV has to be part of an
multi-part form upload.  I've updated the example to reflect that.

Perhaps a CSV body should be accepted. I'm going to be in that code
to add zip file support, so I can allow zip/csv bodies as well.

In the 3rd step, the example left out the element property, which is
required. The error message:

The payload of a POST to the batches catalog must be either:
    * A file upload, with a Content-Type from the set ['text/csv', 'application/csv', 'application/x-spss-sav'],
    * A multipart/form-data upload, with a "file" parameter
        whose Content-Type is from the above set,
    * A crunch:table containing data and, optionally, metadata, or
    * A shoji:entity representing the new Batch. Its "body" must contain either:
        * A 'source' member, with the URL of an existing Source,
        * A 'url' member, with the URL of an s3 resource,
        * A 'dataset' member, with the URL of a different dataset, or
        * A 'stream' member, with the number of
            streamed messages to consume (null for all);
            you must also include a 'type' member defining
            the file type of the streamed rows ('ldjson' or 'csv').

It looks like the 2nd and 3rd steps could be combined. Perhaps that
would be better.

I wonder what percentage of data sets have more than one batch. If the
common case is a single batch, it seems a bit mean to make people go
through multiple steps. <shrug>