### PR TITLE
Added a note that a zip file may be used.

### DIFF
--- a/source/includes/_feature-importing.md
+++ b/source/includes/_feature-importing.md
@@ -4,7 +4,9 @@ There are several ways to build a Crunch dataset. The most appropriate method fo
 
 ### Import from a data file
 
-In some cases, you already have a file sitting on your computer which has source data, in a format like CSV or SPSS. You can upload these to Crunch and then attach them to datasets by following these steps.
+In some cases, you already have a file sitting on your computer which has source data, in CSV or SPSS
+format (or a Zip file containing a single file in CSV or SPSS format). You can upload these to Crunch and
+then attach them to datasets by following these steps.
 
 #### 1. Create a Dataset entity
 


### PR DESCRIPTION
Note that I only updated the "Import from a data file" section.

I didn't touch the "Metadata document + CSV" sections because, as the
section is now written, uploading a Zip file won't work.  This is
because posting content directly checks that the content type is CSV
or SPSS, and I didn't include changing that code in this PR.  OTOH,
Zip import does work in a multi-part post.

I also changed the wording a tad from "format like CSV or SPSS", which implies that other formats are supported (if only you knew what they were ;-) ) to "in CSV or SPSS format".